### PR TITLE
'current' numpy/scipy complain about floats as indices

### DIFF
--- a/bregman/features_base.py
+++ b/bregman/features_base.py
@@ -350,11 +350,11 @@ class Features(object):
         self._dctN = self._cqtN
         self._outN = float(self.nfft/2+1)
         if self._cqtN<1: print "warning: cqtN not positive definite"
-        mxnorm = P.empty(self._cqtN) # Normalization coefficients        
+        mxnorm = P.empty(int(self._cqtN)) # Normalization coefficients
         fftfrqs = self._fftfrqs #P.array([i * self.sample_rate / float(self._fftN) for i in P.arange(self._outN)])
         logfrqs=P.array([lo_edge * P.exp(P.log(2.0)*i/bpo) for i in P.arange(self._cqtN)])
         logfbws=P.array([max(logfrqs[i] * (f_ratio - 1.0), self.sample_rate / float(self._fftN)) 
-                         for i in P.arange(self._cqtN)])
+                         for i in P.arange(int(self._cqtN))])
         #self._fftfrqs = fftfrqs
         self._logfrqs = logfrqs
         self._logfbws = logfbws


### PR DESCRIPTION
Hello, while working through Machine Learning with TensorFlow (great MEAP, btw, thanks for your efforts), I found a problem in the Bregman sound tools. In a couple of places the code was relying on behind-the-scenes `int` conversion when using `float` arguments to `arange` and `empty` - so I added explicit `int()` calls on those cases.

This is likely not an error with older packages - here are my versions for reference:

```
(py2tf) $ python pyverchecker.py
Python version: 2.7.13 |Continuum Analytics, Inc.| (default, Dec 20 2016, 23:05:08)
[GCC 4.2.1 Compatible Apple LLVM 6.0 (clang-600.0.57)]
pandas version: 0.19.2
matplotlib version: 2.0.0
numpy version: 1.12.0
scipy version: 0.18.1
IPython version: 5.3.0
sklearn version: 0.18.1
tensorflow version: 1.0.0
```

I think this patch would not hurt older versions of the code that relied on scipy/numpy calling `int()` "behind the scenes", but I haven't tested that.